### PR TITLE
FIX: image extraction error with multi-word puzzle entries

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -53,13 +53,13 @@ class SetupPuzzleRequest(BaseModel):
 
 
 class ExtractedWords(BaseModel):
-    """Pydantic model for LLM structured output from image word extraction."""
+    """Pydantic model for LLM structured output from image cell content extraction."""
 
     words: List[str] = Field(
         ...,
         min_items=16,
         max_items=16,
-        description="16 words from 4x4 grid in reading order"
+        description="16 items (cell contents) from 4x4 grid in reading order. Each item is the complete text from one cell, which may contain single or multi-word phrases."
     )
     grid_detected: bool = Field(
         ...,


### PR DESCRIPTION
fixes #30 

After updating image extraction prompt, the puzzle is correctly initialized
<img width="750" height="471" alt="image" src="https://github.com/user-attachments/assets/c322c834-154f-441a-90ec-41a4b1aeb9a0" />
